### PR TITLE
Fix basecallingstep1

### DIFF
--- a/scripts/BaseCellCalling/BaseCellCalling.step1.py
+++ b/scripts/BaseCellCalling/BaseCellCalling.step1.py
@@ -223,7 +223,7 @@ def variant_calling_step1(file,alpha1,beta1,alpha2,beta2,min_ac_cells,min_ac_rea
 									# Strand bias test (Fisher's exact test between strands, comparing alt and ref distributions)
 									if (Fisher_cutoff != 1):
 										Fw_dict = {Alleles[x]:int(bcf[x]) for x in range(len(bcf)) if Alleles[x]}
-										Rv_dict = {Alleles[x]:int(bcf[x]) for x in range(len(bcf)) if Alleles[x]}
+										Rv_dict = {Alleles[x]:int(bcr[x]) for x in range(len(bcr)) if Alleles[x]}
 										fisher_p = "|".join([str(round(stats.fisher_exact([[Fw_dict[x], Rv_dict[x]], [Fw_dict[REF], Rv_dict[REF]]])[1],4)) for x in Alt_candidates])
 										Fisher_p.append(fisher_p)
 

--- a/scripts/BaseCellCalling/BaseCellCalling.step1.py
+++ b/scripts/BaseCellCalling/BaseCellCalling.step1.py
@@ -171,7 +171,7 @@ def variant_calling_step1(file,alpha1,beta1,alpha2,beta2,min_ac_cells,min_ac_rea
 							All_DPs[cell_type] = int(DP)
 							All_CCs[cell_type] = int(NC)
 
-							if (int(DP) >= min_cells and int(NC) >= min_reads):
+							if (int(DP) >= min_reads and int(NC) >= min_cells):
 								# Number of cell types with min_BC
 								Cell_types_min_BC = Cell_types_min_BC + 1
 								# Number of cell types with min_CC

--- a/scripts/BaseCellCalling/BaseCellCalling.step1.py
+++ b/scripts/BaseCellCalling/BaseCellCalling.step1.py
@@ -11,7 +11,7 @@ import scipy.stats as stats
 import pandas as pd
 
 def reinit_template(diff_cell_types,min_reads,min_cells):
-	# Creates empty dicctionary for coverage counts
+	# Creates empty dictionary for coverage counts
 	TEMPLATE = {min_reads:0, min_cells:0, 5: 0, 10: 0, 20: 0,30: 0}
 	INFORMATIVE_POSITIONS_TEMPLATE = {x:{'NC':TEMPLATE.copy(),'DP':TEMPLATE.copy()} for x in diff_cell_types}
 	return(INFORMATIVE_POSITIONS_TEMPLATE, TEMPLATE)
@@ -181,7 +181,7 @@ def variant_calling_step1(file,alpha1,beta1,alpha2,beta2,min_ac_cells,min_ac_rea
 								bc = BC.split(":")
 								bq = BQ.split(":")
 								bcf = BCf.split(":") # forward bases
-								bcr = BCr.split(":") # reverese bases
+								bcr = BCr.split(":") # reverse bases
 
 								# Sum all alternative reads
 								Alts2 = sum([int(bc[x]) for x in range(len(bc)) if Alleles[x] not in [REF,"O"]])


### PR DESCRIPTION
- Fixed small typos
- For the int(DP) and int(NC) filters, it appeared to me based on their definitions that they were supposed to be compared against min_reads and min_cells.
- The dictionary of base counts on the reverse strand was not used in the fisher's exact test for strand bias.