### PR TITLE
Add max_depth option for pysam.pileup in BaseCellCounter.py and SingleCellGenotype.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The first step consists of splitting the BAM file containing aligned sequencing 
 Step 1 is executed using the script SplitBam/SplitBamCellTypes.py, which has the following parameters:
 
 - List of parameters:
-```
+```python
 python scripts/SplitBam/SplitBamCellTypes.py --help
 usage: SplitBamCellTypes.py [-h] --bam BAM --meta META [--id ID]
                             [--max_nM MAX_NM] [--max_NH MAX_NH]
@@ -112,7 +112,7 @@ Base count information for each cell type and for every position in the genome i
 The command line to run this step is: 
 
 - List of parameters:
-```
+```python
 python scripts/BaseCellCounter/BaseCellCounter.py --help
 usage: BaseCellCounter.py [-h] --bam BAM --ref REF --chrom CHROM
                                    [--out_folder OUT_FOLDER] [--id ID]
@@ -153,6 +153,9 @@ optional arguments:
                         Default = 20
   --min_mq MIN_MQ       Minimum mapping quality required to analyse read.
                         Default = 255
+  --max_dp MAX_DP       Maximum number of reads per genomic site that are read by pysam pileup,
+                        to save time and memory. Set this value to 0 to switch this filter off
+                        (recommended for high-depth sequencing). [Default: 8000]
   --tmp_dir TMP_DIR     Temporary folder for tmp files
 ```
 

--- a/docs/OtherFunctionalities.md
+++ b/docs/OtherFunctionalities.md
@@ -100,6 +100,9 @@ optional arguments:
                         Default = 30
   --min_mq MIN_MQ       Minimum mapping quality required to analyse read.
                         Default = 255
+  --max_dp MAX_DP       Maximum number of reads per genomic site that are read by pysam pileup,
+                        to save time and memory. Set this value to 0 to switch this filter off
+                        (recommended for high-depth sequencing). [Default: 8000]
   --tissue TISSUE       Tissue of the sample
   --tmp_dir TMP_DIR     Temporary folder for tmp files
 ```

--- a/scripts/BaseCellCalling/BaseCellCalling.step1.py
+++ b/scripts/BaseCellCalling/BaseCellCalling.step1.py
@@ -171,7 +171,7 @@ def variant_calling_step1(file,alpha1,beta1,alpha2,beta2,min_ac_cells,min_ac_rea
 							All_DPs[cell_type] = int(DP)
 							All_CCs[cell_type] = int(NC)
 
-							if (int(DP) >= min_cells and int(NC) >= min_reads):
+							if (int(DP) >= min_reads and int(NC) >= min_cells):
 								# Number of cell types with min_BC
 								Cell_types_min_BC = Cell_types_min_BC + 1
 								# Number of cell types with min_CC


### PR DESCRIPTION
- Added a max_dp option in `BaseCellCounter.py` and `SingleCellGenotype.py` as discussed in #63
- For the int(DP) and int(NC) filters in `BaseCellCalling.step1.py`, swapped min_reads and min_cells (from #16)